### PR TITLE
fix can not bootstrap in the cloud

### DIFF
--- a/package.oo.yaml
+++ b/package.oo.yaml
@@ -5,7 +5,7 @@ scripts:
   bootstrap: |
     pnpm install 
     apt update && apt install -y openssh-client
-    wget https://static.oomol.com/sshexec/v1.0.10/installer.sh --output-document /tmp/installer.sh
+    wget https://static.oomol.com/sshexec/v1.0.12/installer.sh --output-document /tmp/installer.sh
     bash +x /tmp/installer.sh
 dependencies:
   oomol-file: 0.0.9


### PR DESCRIPTION
when `OO_HOST_PLATFORM=linux` set in cloud, install the Linux version of ffmpeg instead of using [caller](https://github.com/oomol/sshexec/releases/download/v1.0.12/caller-arm64)